### PR TITLE
Fix determine host from request when not set via application config

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val play27 = ConfigAxis("play27", "play2.7")
 lazy val play28 = ConfigAxis("play28", "play2.8")
 
 lazy val scala212 = "2.12.13"
-lazy val scala213 = "2.13.4"
+lazy val scala213 = "2.13.6"
 
 lazy val root = (project in file("."))
   .aggregate(swagger.projectRefs: _*)

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ api.version = beta
 swagger.filter = null
 swagger.api {
   basepath = "/"
-  host = "localhost:9000"
+  host = ""
   title = ""
   schemes = []
 

--- a/src/main/scala/controllers/ApiHelpController.scala
+++ b/src/main/scala/controllers/ApiHelpController.scala
@@ -61,11 +61,24 @@ class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) 
   def setMessage(message: String) = this.message = message
 }
 
+/**
+ * For Java8, add support for a `aString.is_blank` function.
+ * Cannot be called `isBlank` since that conflicts with Java 11's `java.lang.String.isBlank`.
+ * Can be removed in favor of `java.lang.String.isBlank` when updating to Java 11.
+ */
+object Java8Utils {
+  implicit class StringExtension(val s: String) extends AnyVal {
+    def is_blank: Boolean = s.trim == ""
+  }
+}
+
 class ApiHelpController @Inject() (components: ControllerComponents, val swaggerPlugin: SwaggerPlugin)
   extends AbstractController(components) with SwaggerBaseApiController {
 
+  import Java8Utils.StringExtension
+
   def getResources = Action { implicit request =>
-    val host = if (swaggerPlugin.config.host.isBlank) request.host else swaggerPlugin.config.host
+    val host = if (swaggerPlugin.config.host.is_blank) request.host else swaggerPlugin.config.host
     val resourceListing: Swagger = getResourceListing(host)
     val response: String = returnXml(request) match {
       case true => toXmlString(resourceListing)
@@ -75,7 +88,7 @@ class ApiHelpController @Inject() (components: ControllerComponents, val swagger
   }
 
   def getResource(path: String) = Action { implicit request =>
-    val host = if (swaggerPlugin.config.host.isBlank) request.host else swaggerPlugin.config.host
+    val host = if (swaggerPlugin.config.host.is_blank) request.host else swaggerPlugin.config.host
     val apiListing: Swagger = getApiListing(path, host)
     val response: String = returnXml(request) match {
       case true => toXmlString(apiListing)

--- a/src/main/scala/controllers/ApiHelpController.scala
+++ b/src/main/scala/controllers/ApiHelpController.scala
@@ -65,7 +65,7 @@ class ApiHelpController @Inject() (components: ControllerComponents, val swagger
   extends AbstractController(components) with SwaggerBaseApiController {
 
   def getResources = Action { implicit request =>
-    val host: String = swaggerPlugin.config.host
+    val host = if (swaggerPlugin.config.host.isBlank) request.host else swaggerPlugin.config.host
     val resourceListing: Swagger = getResourceListing(host)
     val response: String = returnXml(request) match {
       case true => toXmlString(resourceListing)
@@ -75,7 +75,7 @@ class ApiHelpController @Inject() (components: ControllerComponents, val swagger
   }
 
   def getResource(path: String) = Action { implicit request =>
-    val host: String = swaggerPlugin.config.host
+    val host = if (swaggerPlugin.config.host.isBlank) request.host else swaggerPlugin.config.host
     val apiListing: Swagger = getApiListing(path, host)
     val response: String = returnXml(request) match {
       case true => toXmlString(apiListing)

--- a/src/main/scala/controllers/ApiHelpController.scala
+++ b/src/main/scala/controllers/ApiHelpController.scala
@@ -61,24 +61,11 @@ class ErrorResponse(@XmlElement var code: Int, @XmlElement var message: String) 
   def setMessage(message: String) = this.message = message
 }
 
-/**
- * For Java8, add support for a `aString.is_blank` function.
- * Cannot be called `isBlank` since that conflicts with Java 11's `java.lang.String.isBlank`.
- * Can be removed in favor of `java.lang.String.isBlank` when updating to Java 11.
- */
-object Java8Utils {
-  implicit class StringExtension(val s: String) extends AnyVal {
-    def is_blank: Boolean = s.trim == ""
-  }
-}
-
 class ApiHelpController @Inject() (components: ControllerComponents, val swaggerPlugin: SwaggerPlugin)
   extends AbstractController(components) with SwaggerBaseApiController {
 
-  import Java8Utils.StringExtension
-
   def getResources = Action { implicit request =>
-    val host = if (swaggerPlugin.config.host.is_blank) request.host else swaggerPlugin.config.host
+    val host: String = swaggerPlugin.config.host
     val resourceListing: Swagger = getResourceListing(host)
     val response: String = returnXml(request) match {
       case true => toXmlString(resourceListing)
@@ -88,7 +75,7 @@ class ApiHelpController @Inject() (components: ControllerComponents, val swagger
   }
 
   def getResource(path: String) = Action { implicit request =>
-    val host = if (swaggerPlugin.config.host.is_blank) request.host else swaggerPlugin.config.host
+    val host: String = swaggerPlugin.config.host
     val apiListing: Swagger = getApiListing(path, host)
     val response: String = returnXml(request) match {
       case true => toXmlString(apiListing)


### PR DESCRIPTION
In Swagger-Play 1.7.1 a change was made which only allowed the host to be set via the configuration with a default value of `localhost:9000`.
This is problematic since that makes it difficult to get the correct `host` in the `swagger.conf` since the service might be available on different ports depending on the environment (development, accept/prod, in docker, in IDE, etc).
With a wrong `host` the Swagger docs do not 'work' anymore.

This fixes the issue by changing the default to empty ("") and use the `request.host` in case the configured host is empty.
So this still allowes setting the host to a fixed value, but now also allows to get host dynamically from the request.